### PR TITLE
Makefile: do not run depmod manually

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ modules:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) PROJECT_DIR=$(PWD) modules
 modules_install:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
-	@depmod
 endif
 .PHONY: clean
 clean:


### PR DESCRIPTION
The kernel build infrastructure already runs depmod properly in its
modules_install target, doing so in a cross-compilation friendly way. Running it
with no arguments is useless and also harmful since it breaks cross-compilation
contexts by scanning dependencies on the modules installed on the host instead
of those being built for the target.

Patches with similar motivation where accepted by other projects providing external kernel modules and widely used in cross-compilation environments. See i.e. [lttng-modules](https://github.com/lttng/lttng-modules/commit/dc1f0d57008b54beda38cb502407d5a1b1332a27) or [v4l2loopback](https://github.com/umlaeute/v4l2loopback/commit/eac5e95bec0da7ae49dd0e1942fcd3a3948a724a) as a reference.