### PR TITLE
Added MSG_PEEK to the allowed flags check in isotp_recvmsg function

### DIFF
--- a/net/can/isotp.c
+++ b/net/can/isotp.c
@@ -1045,7 +1045,7 @@ static int isotp_recvmsg(struct kiocb *iocb, struct socket *sock,
 	int noblock = flags & MSG_DONTWAIT;
 	int ret = 0;
 
-	if (flags & ~(MSG_DONTWAIT | MSG_TRUNC))
+	if (flags & ~(MSG_DONTWAIT | MSG_TRUNC | MSG_PEEK))
 		return -EINVAL;
 
 	if (!so->bound)


### PR DESCRIPTION
To be able to get the size of the buffer to allocate for the next message without removing the message from the receive queue, the caller needs to be able to set the `flags` to `MSG_PEEK | MSG_TRUNC`. 

This patch restores the ability of the caller to set the `MSG_PEEK` flag in a call to [recv](https://man7.org/linux/man-pages/man2/recv.2.html) which was accidentally removed while adding support for the `MSG_TRUNC` flag in this [commit](https://github.com/hartkopp/can-isotp/commit/f51b3b3bb1df6e96357d9631a2fcb94657d409f4).